### PR TITLE
Fix: make deployed site link open in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source code for a website listing interesting facts about CYF's host cities. You can use it to practise creating issues and pull requests, and to study the examples which are already here.
 
-You can see the deployed site [here](https://codeyourfuture.github.io/github_issues_prs_practice/).
+You can see the deployed site <a href="https://codeyourfuture.github.io/github_issues_prs_practice/" target="_blank">here</a>.
 
 ## Repository Contents
 


### PR DESCRIPTION
Added HTML <a> tag with target="_blank", but due to GitHub’s sanitization the link still opens in the same tab