### PR TITLE
Add fact about London Underground being the world's oldest subway system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the source code for a website listing interesting facts about CYF's host cities. You can use it to practise creating issues and pull requests, and to study the examples which are already here.
 
-You can see the deployed site [here](https://codeyourfuture.github.io/github_issues_prs_practice/).
+You can see the deployed site <a href="https://codeyourfuture.github.io/github_issues_prs_practice/" target="_blank">here</a>.
 
 ## Repository Contents
 

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
                     <li>Holds the record for most Olympic Games hosted by a city</li>
                     <li>The shortest street is only 36ft long</li>
                     <li>Has so many trees that it meets the UN's <a href="https://www.un-redd.org/glossary/forest">definition of a forest</a></li>
+                    <li>The London Underground is the world’s oldest subway system, opened in 1863</li>
                 </ul>
             </div>
             <img src="https://img.freepik.com/free-photo/view-london-skyline-by-night_268835-1398.jpg" alt="London skyline at night">


### PR DESCRIPTION
Added a fifth fact for London to keep consistency with other cities.
The fact: The London Underground is the world’s oldest subway system, opened in 1863.
